### PR TITLE
Release/3.2 and IDFA usage changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ---
 
+## [3.2](https://github.com/bear2b/bear_sdk_demo_ios/releases/tag/3.2) Xcode 12.5 / Swift 5.4
+
+### Addedd
+
+* disable using IDFA by default and add ability to re-enable it in config;
+
+### Changed
+
+* recompiled with Xcode 12.5, Swift 5.4;
+
 ## [3.0.8](https://github.com/bear2b/bear_sdk_demo_ios/releases/tag/3.0.8) Xcode 12.4 / Swift 5.3.2
 
 ### Changed

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "Alamofire/Alamofire" == 5.4.1
+github "Alamofire/Alamofire" == 5.4.3
 github "ReactiveX/RxSwift" == 5.1.2
-binary "https://s3.eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/BearSDK.json" == 3.0.8
+binary "https://s3.eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/BearSDK.json" == 3.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://s3.eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/BearSDK.json" "3.0.8"
-github "Alamofire/Alamofire" "5.4.1"
+binary "https://s3.eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/BearSDK.json" "3.2"
+github "Alamofire/Alamofire" "5.4.3"
 github "ReactiveX/RxSwift" "5.1.2"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Example of `Cartfile` included in sample app.
 Add this to your `Cartfile` file:
 
 ```bash
-github "Alamofire/Alamofire" == 5.4.1
+github "Alamofire/Alamofire" == 5.4.3
 github "ReactiveX/RxSwift" == 5.1.2
-binary "https://s3.eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/BearSDK.json" == 3.0.8
+binary "https://s3.eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/BearSDK.json" == 3.2
 ```
 
 ``` bash
@@ -92,7 +92,7 @@ platform :ios, '12.0'
 use_frameworks!
 
 target `YourApp` do
-    pod 'BearSDK', '3.0.8'
+    pod 'BearSDK', '3.2'
 end
 ```
 
@@ -102,7 +102,7 @@ pod install
 
 ### Manual
 
-* Download [zip archive](https://s3-eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/3.0.5/BearSDK.framework.zip);
+* Download [zip archive](https://s3-eu-west-1.amazonaws.com/mobile-dev.bear2b.com/bearsdk-ios/3.2/BearSDK.framework.zip);
 * Add to *Frameworks, Libraries, and Embedded Content* section in your project `BearGL.framework` and `Vuforia.framework` together with `BearSDK.framework`.
 * Integrate dependencies as you wish - [Carthage](https://github.com/Carthage/Carthage) or [CocoaPods](https://cocoapods.org) or [Swift Package Manager](https://github.com/apple/swift-package-manager) or manually.
 


### PR DESCRIPTION
recompiled with Xcode 12.5, Swift 5.4
disable using IDFA by default and add ability to re-enable it in config
